### PR TITLE
Badge URLs point to Altai-man/perl6-Compress-Bzip2-Raw repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 P6-Compress-Bzip2-Raw
 ====================
 
-[![Linux](https://github.com/pmqs/perl6-Compress-Bzip2-Raw/actions/workflows/linux.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2-Raw/actions/workflows/linux.yml)
-[![MacOS](https://github.com/pmqs/perl6-Compress-Bzip2-Raw/actions/workflows/macos.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2-Raw/actions/workflows/macos.yml)
-[![Windows](https://github.com/pmqs/perl6-Compress-Bzip2-Raw/actions/workflows/windows.yml/badge.svg)](https://github.com/pmqs/perl6-Compress-Bzip2-Raw/actions/workflows/windows.yml)
+[![Linux](https://github.com/Altai-man/perl6-Compress-Bzip2-Raw/actions/workflows/linux.yml/badge.svg)](https://github.com/Altai-man/perl6-Compress-Bzip2-Raw/actions/workflows/linux.yml)
+[![MacOS](https://github.com/Altai-man/perl6-Compress-Bzip2-Raw/actions/workflows/macos.yml/badge.svg)](https://github.com/Altai-man/perl6-Compress-Bzip2-Raw/actions/workflows/macos.yml)
+[![Windows](https://github.com/Altai-man/perl6-Compress-Bzip2-Raw/actions/workflows/windows.yml/badge.svg)](https://github.com/Altai-man/perl6-Compress-Bzip2-Raw/actions/workflows/windows.yml)
 
 Low-level interface to bzip2. Bzip2 library must be installed in the system. Contributions are welcome.


### PR DESCRIPTION
Ooops! The badge URLs I created in  in `README.md`  for https://github.com/Altai-man/perl6-Compress-Bzip2-Raw/pull/5 point to my fork of your repo. This PR fixes them to point to the correct place. 